### PR TITLE
Made spreading plants have their can spread on be based on a tag

### DIFF
--- a/common/src/generated/resources/.cache/58d48db7bd03befddf357f7f70ed6e5c46284769
+++ b/common/src/generated/resources/.cache/58d48db7bd03befddf357f7f70ed6e5c46284769
@@ -1,14 +1,16 @@
-// 1.21.1	2025-05-09T15:47:33.95294	Tags for minecraft:block mod id enchanted
+// 1.21.1	2025-05-28T11:40:50.301563	Tags for minecraft:block mod id enchanted
 123a7429e38219f04121d70ae9d6e353a3c61d48 data/enchanted/tags/block/alder_logs.json
+032a28906df93325eea0f3c0b2070e0f2344aa47 data/enchanted/tags/block/blight_decay_blocks.json
 69c396cb051bbe9a130e6979b67065e5041b179d data/enchanted/tags/block/blight_decayable_blocks.json
 db77d76070801e3294b77d64cfc0adaeb8972d36 data/enchanted/tags/block/blight_decayable_plants.json
-032a28906df93325eea0f3c0b2070e0f2344aa47 data/enchanted/tags/block/blight_decay_blocks.json
 181fea80d046f4ab0fe3aa89579ae39eb6bc9c87 data/enchanted/tags/block/broom_sweepable.json
 e7ff58a601c24e056dc5521f018555f7e596ec4e data/enchanted/tags/block/chalices.json
 cc0b47d4892d7d2ed9f5813df5bc1d69754bd3ef data/enchanted/tags/block/chalks.json
 bc7721a66aee97cea11dffcfa62295799c09460b data/enchanted/tags/block/crops.json
-af21188360929836cdf79542ec2c5b1ff6032459 data/enchanted/tags/block/fences.json
+75dba89f697956e874f2cadecb3b09a0d89f0c6a data/enchanted/tags/block/ember_moss_spreads_on.json
 11c11e8d3eb37d55c44dfbad3c5d2fc892bd4fd2 data/enchanted/tags/block/fence_gates.json
+af21188360929836cdf79542ec2c5b1ff6032459 data/enchanted/tags/block/fences.json
+75dba89f697956e874f2cadecb3b09a0d89f0c6a data/enchanted/tags/block/glint_weed_spreads_on.json
 2b6211b51490f8caac3959b72e04e988a45ebc11 data/enchanted/tags/block/hawthorn_logs.json
 847203a50ec44d614777e94b9ece91cefd7d94fa data/enchanted/tags/block/leaves.json
 7d4d6af77b94f2dc243f0abdd68d45eabf56905e data/enchanted/tags/block/logs.json
@@ -29,8 +31,8 @@ b1bf603e14a40fa231fcff7776962ebc9b20d72e data/enchanted/tags/block/rowan_logs.js
 990b5a153ba74d4169b814216548205322d8dc22 data/enchanted/tags/block/wooden_stairs.json
 32adfa97bb5b4f7b8c06529d3445fb9489cfd873 data/minecraft/tags/block/climbable.json
 26218d57e208f3721ed88151e14ff84c0d671c55 data/minecraft/tags/block/crops.json
-a63c9ec100ada9b80c9c27ba66474b9ccdaff9ef data/minecraft/tags/block/fences.json
 db79e7fde09cdd640b1b64f690b5471b2911d128 data/minecraft/tags/block/fence_gates.json
+a63c9ec100ada9b80c9c27ba66474b9ccdaff9ef data/minecraft/tags/block/fences.json
 115f6d9fa2c6915eed7935e8b664a6a502fc0624 data/minecraft/tags/block/leaves.json
 6300f7d8da269a5dcee09988742bf91315883e2a data/minecraft/tags/block/logs_that_burn.json
 15f25336a7876d1c20a793265f7774f0f87273bf data/minecraft/tags/block/mineable/axe.json

--- a/common/src/generated/resources/data/enchanted/tags/block/ember_moss_spreads_on.json
+++ b/common/src/generated/resources/data/enchanted/tags/block/ember_moss_spreads_on.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:grass_block",
+    "minecraft:dirt",
+    "minecraft:sand"
+  ]
+}

--- a/common/src/generated/resources/data/enchanted/tags/block/glint_weed_spreads_on.json
+++ b/common/src/generated/resources/data/enchanted/tags/block/glint_weed_spreads_on.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:grass_block",
+    "minecraft:dirt",
+    "minecraft:sand"
+  ]
+}

--- a/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/AbstractSpreadingBlock.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/AbstractSpreadingBlock.java
@@ -14,7 +14,7 @@ public abstract class AbstractSpreadingBlock extends Block {
 
     @Override
     public void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
-        if(!canSpreadOn(level.getBlockState(pos.below()).getBlock()))
+        if(!canSpreadOn(level.getBlockState(pos.below())))
             return;
         if (random.nextInt(25) == 0) {
             int i = 5;
@@ -43,7 +43,7 @@ public abstract class AbstractSpreadingBlock extends Block {
 
     }
 
-    public boolean canSpreadOn(Block block) {
+    public boolean canSpreadOn(BlockState block) {
         return true;
     }
 }

--- a/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/EmberMossBlock.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/EmberMossBlock.java
@@ -1,5 +1,6 @@
 package net.favouriteless.enchanted.common.blocks.crops;
 
+import net.favouriteless.enchanted.common.init.ETags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
@@ -7,7 +8,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -35,8 +35,8 @@ public class EmberMossBlock extends AbstractSpreadingBlock {
     }
 
     @Override
-    public boolean canSpreadOn(Block block) {
-        return block == Blocks.GRASS_BLOCK || block == Blocks.DIRT || block == Blocks.SAND;
+    public boolean canSpreadOn(BlockState block) {
+        return block.is(ETags.Blocks.EMBER_MOSS_SPREADS_ON);
     }
 
 }

--- a/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/GlintWeedBlock.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/blocks/crops/GlintWeedBlock.java
@@ -1,11 +1,10 @@
 package net.favouriteless.enchanted.common.blocks.crops;
 
+import net.favouriteless.enchanted.common.init.ETags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class GlintWeedBlock extends AbstractSpreadingBlock {
@@ -24,8 +23,8 @@ public class GlintWeedBlock extends AbstractSpreadingBlock {
     }
 
     @Override
-    public boolean canSpreadOn(Block block) {
-        return block == Blocks.GRASS_BLOCK || block == Blocks.DIRT || block == Blocks.SAND;
+    public boolean canSpreadOn(BlockState block) {
+        return block.is(ETags.Blocks.GLINT_WEED_SPREADS_ON);
     }
 
 }

--- a/common/src/main/java/net/favouriteless/enchanted/common/init/ETags.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/init/ETags.java
@@ -22,8 +22,10 @@ public class ETags {
         public static final TagKey<Block> CHALICES = createBlockTag("chalices");
         public static final TagKey<Block> CHALKS = createBlockTag("chalks");
         public static final TagKey<Block> CROPS = createBlockTag("crops");
+        public static final TagKey<Block> EMBER_MOSS_SPREADS_ON = createBlockTag("ember_moss_spreads_on");
         public static final TagKey<Block> FENCES = createBlockTag("fences");
         public static final TagKey<Block> FENCE_GATES = createBlockTag("fence_gates");
+        public static final TagKey<Block> GLINT_WEED_SPREADS_ON = createBlockTag("glint_weed_spreads_on");
         public static final TagKey<Block> HAWTHORN_LOGS = createBlockTag("hawthorn_logs");
         public static final TagKey<Block> LEAVES = createBlockTag("leaves");
         public static final TagKey<Block> LOGS = createBlockTag("logs");

--- a/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/providers/tag/EBlockTagProvider.java
+++ b/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/providers/tag/EBlockTagProvider.java
@@ -49,10 +49,14 @@ public class EBlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
         tag(ETags.Blocks.CROPS)
                 .add(EBlocks.BELLADONNA.get(), EBlocks.SNOWBELL.get(), EBlocks.MANDRAKE.get(), EBlocks.GARLIC.get(),
                         EBlocks.WOLFSBANE.get());
+        tag(ETags.Blocks.EMBER_MOSS_SPREADS_ON)
+                .add(Blocks.GRASS_BLOCK, Blocks.DIRT, Blocks.SAND);
         tag(ETags.Blocks.FENCES)
                 .addTag(ETags.Blocks.WOODEN_FENCES);
         tag(ETags.Blocks.FENCE_GATES)
                 .add(EBlocks.ALDER_FENCE_GATE.get(), EBlocks.HAWTHORN_FENCE_GATE.get(), EBlocks.ROWAN_FENCE_GATE.get());
+        tag(ETags.Blocks.GLINT_WEED_SPREADS_ON)
+                .add(Blocks.GRASS_BLOCK, Blocks.DIRT, Blocks.SAND);
         tag(ETags.Blocks.HAWTHORN_LOGS)
                 .add(EBlocks.HAWTHORN_LOG.get(), EBlocks.STRIPPED_HAWTHORN_LOG.get());
         tag(ETags.Blocks.LEAVES)


### PR DESCRIPTION
Why?
A lot of mods like biomes o plenty may add their own dirt or grass which makes finding vanilla grass impossible, this would allow modpack makers to add those to the tag. This is especially a problem if you are trying to make enchanted work with TFC.

I have tried to keep my changes as minimal as possible however here is what I changed:
- canSpreadOn now uses a blockstate instead of a block, this was needed to allow for usage of `is(...tag...)`
- Added tags for both glint weed spreads on and ember moss spreads on

What I verified:
- I tested that it works on neoforge
- I tested that both dirt, grass and sand allow both of the plants to spread

What I haven't verified:
- Fabric, but if I had to guess it shouldn't be a problem

Future considerations:
- I didn't actually change the list of blocks they can spread on, so this PR does not add any extra compatibility, it might be a good idea to change to using dirt and sand tags for this.

Also another thing, while working on this, I have seen that the can spread on works when the original plant is on an allowed block and not the new one, I would assume this is semi-intended?