### PR TITLE
1.20.1 - NPE when creating bound entity item

### DIFF
--- a/common/src/main/java/net/favouriteless/enchanted/common/circle_magic/rites/EntityBoundCreateItemRite.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/circle_magic/rites/EntityBoundCreateItemRite.java
@@ -4,7 +4,6 @@ import net.favouriteless.enchanted.common.init.registry.EItems;
 import net.favouriteless.enchanted.common.items.TaglockFilledItem;
 import net.favouriteless.enchanted.common.util.WaystoneHelper;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.item.ItemEntity;

--- a/common/src/main/java/net/favouriteless/enchanted/common/circle_magic/rites/EntityBoundCreateItemRite.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/circle_magic/rites/EntityBoundCreateItemRite.java
@@ -31,7 +31,7 @@ public class EntityBoundCreateItemRite extends Rite {
             if(stack.getItem() == EItems.TAGLOCK_FILLED.get()) {
                 if(stack.hasTag() && stack.getTag().contains(TaglockFilledItem.TARGET_TAG)) {
                     ref = stack.getTag().getUUID(TaglockFilledItem.TARGET_TAG);
-                    name = level.getEntity(ref).getName().getString();
+                    name = stack.getTag().getString(TaglockFilledItem.NAME_TAG);
                     break;
                 }
             }


### PR DESCRIPTION
Uses taglock nbt data to pull entity name instead of querying the level.

Potential issues: making this change assumes the taglock is the final word on entity name; for example, getting a taglock from a named pet, renaming the pet, then making a blooded waystone will deadname the pet. Probably fine though, pretty niche case and most people who do this will know what they're doin

Fixes #84