### PR TITLE
Fix JEI/EMI transfer recipe button interaction. Fix recipe viewer slo…

### DIFF
--- a/common/src/main/java/net/favouriteless/enchanted/integrations/jei/DistilleryTransferInfo.java
+++ b/common/src/main/java/net/favouriteless/enchanted/integrations/jei/DistilleryTransferInfo.java
@@ -1,5 +1,6 @@
 package net.favouriteless.enchanted.integrations.jei;
 
+import net.favouriteless.enchanted.common.init.registry.EItems;
 import net.favouriteless.enchanted.common.init.registry.EMenuTypes;
 import net.favouriteless.enchanted.common.menus.DistilleryMenu;
 import net.favouriteless.enchanted.common.recipes.DistillingRecipe;
@@ -7,9 +8,11 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DistilleryTransferInfo implements IRecipeTransferInfo<DistilleryMenu, DistillingRecipe> {
 
@@ -25,7 +28,16 @@ public class DistilleryTransferInfo implements IRecipeTransferInfo<DistilleryMen
 
     @Override
     public List<Slot> getRecipeSlots(DistilleryMenu container, DistillingRecipe recipe) {
-        return container.slots.subList(0, 3);
+        // Check to see if the recipe contains a "container" item.
+        int firstSlotIndex = 1;
+        for(ItemStack input : recipe.getItemsIn()) {
+            // Should probably be replaced with a tag check.
+            if (input.is(EItems.CLAY_JAR.get())) {
+                firstSlotIndex = 0;
+            }
+        }
+
+        return container.slots.subList(firstSlotIndex, 3);
     }
 
     @Override

--- a/common/src/main/java/net/favouriteless/enchanted/integrations/jei/categories/DistillingCategory.java
+++ b/common/src/main/java/net/favouriteless/enchanted/integrations/jei/categories/DistillingCategory.java
@@ -43,11 +43,15 @@ public class DistillingCategory implements IRecipeCategory<DistillingRecipe> {
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, DistillingRecipe recipe, IFocusGroup focuses) {
-        builder.addSlot(RecipeIngredientRole.INPUT, 28, 30).addIngredient(VanillaTypes.ITEM_STACK, recipe.getItemsIn().get(0));
-        int offset = 0;
+        int offset = 20;
         for (ItemStack i : recipe.getItemsIn()) {
-            if (offset != 0)
-                builder.addSlot(RecipeIngredientRole.INPUT, 50, offset).addIngredient(VanillaTypes.ITEM_STACK, i);
+            // Special case "container" items. Will break if multiple stacks are present.
+            // Should probably be a tag check.
+            if (i.is(EItems.CLAY_JAR.get())) {
+                builder.addSlot(RecipeIngredientRole.INPUT, 28, 30).addIngredient(VanillaTypes.ITEM_STACK, i);
+                continue;
+            }
+            builder.addSlot(RecipeIngredientRole.INPUT, 50, offset).addIngredient(VanillaTypes.ITEM_STACK, i);
             offset += 20;
         }
         offset = 0;


### PR DESCRIPTION
…t display. Tested on Forge client.

Should resolve https://github.com/ACCBDD/reclamation-dev/issues/233 and https://github.com/ACCBDD/reclamation-dev/issues/188

I see you started to fix the problem on 1.21.x, so I didn't bother porting the fix forward. However, I believe you'll still need to correct the transfer handler. Since you're filtering the first slot in your screen, you'll need to filter it in the transfer handler as well. You might want to reconsider your assumption that any container item will be the first recipe ingredient - unless you've added code to enforce that.

