### PR TITLE
Fixes #105 by adding compost data map generator for NeoForge

### DIFF
--- a/common/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
+++ b/common/src/generated/resources/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
@@ -1,0 +1,2 @@
+// 1.21.1	2026-02-27T11:02:50.550461901	Data Maps
+fbbffb77502d35452cf4d0d9f834502c787d0979 data/neoforge/data_maps/item/compostables.json

--- a/common/src/generated/resources/data/neoforge/data_maps/item/compostables.json
+++ b/common/src/generated/resources/data/neoforge/data_maps/item/compostables.json
@@ -1,0 +1,34 @@
+{
+  "values": {
+    "enchanted:belladonna_flower": {
+      "chance": 0.65
+    },
+    "enchanted:belladonna_seeds": {
+      "chance": 0.3
+    },
+    "enchanted:garlic": {
+      "chance": 0.45
+    },
+    "enchanted:mandrake_root": {
+      "chance": 0.65
+    },
+    "enchanted:mandrake_seeds": {
+      "chance": 0.3
+    },
+    "enchanted:snowbell_seeds": {
+      "chance": 0.3
+    },
+    "enchanted:water_artichoke": {
+      "chance": 0.65
+    },
+    "enchanted:water_artichoke_seeds": {
+      "chance": 0.3
+    },
+    "enchanted:wolfsbane_flower": {
+      "chance": 0.65
+    },
+    "enchanted:wolfsbane_seeds": {
+      "chance": 0.3
+    }
+  }
+}

--- a/common/src/main/java/net/favouriteless/enchanted/common/init/EItems.java
+++ b/common/src/main/java/net/favouriteless/enchanted/common/init/EItems.java
@@ -251,6 +251,7 @@ public class EItems {
 	}
 
 	public static void registerCompostables() {
+		// See ECompostMapProvider in data generation for Neoforge registration, as Neoforge does not use this map
 		ComposterBlock.COMPOSTABLES.put(WATER_ARTICHOKE_SEEDS.get(), 0.3F);
 		ComposterBlock.COMPOSTABLES.put(WATER_ARTICHOKE.get(), 0.65F);
 		ComposterBlock.COMPOSTABLES.put(SNOWBELL_SEEDS.get(), 0.3F);

--- a/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/DataGenerators.java
+++ b/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/DataGenerators.java
@@ -37,6 +37,7 @@ public class DataGenerators {
 		gen.addProvider(true, new EBiomeTagProvider(output, provider, fileHelper));
 		gen.addProvider(true, new EDamageTypeTagProvider(output, provider, fileHelper));
 		gen.addProvider(true, new ERecipeProvider(output, provider));
+		gen.addProvider(true, new ECompostMapProvider(output, provider));
 
 		// Assets
 		gen.addProvider(true, new BlockstateProvider(output, fileHelper));

--- a/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/providers/ECompostMapProvider.java
+++ b/neoforge/src/main/java/net/favouriteless/enchanted/neoforge/datagen/providers/ECompostMapProvider.java
@@ -1,0 +1,33 @@
+package net.favouriteless.enchanted.neoforge.datagen.providers;
+
+import net.favouriteless.enchanted.common.init.EItems;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.common.data.DataMapProvider;
+import net.neoforged.neoforge.registries.datamaps.builtin.Compostable;
+import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+
+public class ECompostMapProvider extends DataMapProvider {
+    public ECompostMapProvider(PackOutput packOutput, CompletableFuture<Provider> lookupProvider) {
+        super(packOutput, lookupProvider);
+    }
+
+    @Override
+    protected void gather(@Nonnull HolderLookup.Provider provider) {
+        this.builder(NeoForgeDataMaps.COMPOSTABLES)
+                .add(EItems.WATER_ARTICHOKE_SEEDS.get().builtInRegistryHolder(), new Compostable(0.3f), false)
+                .add(EItems.WATER_ARTICHOKE.get().builtInRegistryHolder(), new Compostable(0.65f), false)
+                .add(EItems.SNOWBELL_SEEDS.get().builtInRegistryHolder(), new Compostable(0.3f), false)
+                .add(EItems.BELLADONNA_SEEDS.get().builtInRegistryHolder(), new Compostable(0.3f), false)
+                .add(EItems.BELLADONNA_FLOWER.get().builtInRegistryHolder(), new Compostable(0.65f), false)
+                .add(EItems.MANDRAKE_SEEDS.get().builtInRegistryHolder(), new Compostable(0.3f), false)
+                .add(EItems.MANDRAKE_ROOT.get().builtInRegistryHolder(), new Compostable(0.65f), false)
+                .add(EItems.WOLFSBANE_SEEDS.get().builtInRegistryHolder(), new Compostable(0.3f), false)
+                .add(EItems.WOLFSBANE_FLOWER.get().builtInRegistryHolder(), new Compostable(0.65f), false)
+                .add(EItems.GARLIC.get().builtInRegistryHolder(), new Compostable(0.45f), false);
+    }
+}


### PR DESCRIPTION
 - Neoforge does not use ComposterBlock#COMPOSTABLES
 - Instead, they use a data map to allow easier extension
 - Thus, a data map generator is added to rectify the issue